### PR TITLE
Fix ImportError: No module named kubernetes.

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -1,5 +1,6 @@
 - hosts: all
   vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
     size: 4
     greeting: Hello
     meta:


### PR DESCRIPTION
Latest minikube version (v1.1.0) produces this error without setting 'ansible_python_interpreter' extra var:

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named kubernetes.